### PR TITLE
Fix deletion of empty log streams

### DIFF
--- a/.release
+++ b/.release
@@ -1,3 +1,3 @@
-release=0.2.5
-tag=v0.2.5
+release=0.2.6
+tag=v0.2.6
 pre_tag_command=sed -i '' -e 's/lambdas\/aws-cloudwatch-log-minder.*\.zip/lambdas\/aws-cloudwatch-log-minder-@@RELEASE@@.zip/g' cloudformation/aws-cloudwatch-log-minder.yaml README.md && sed -i '' -e 's/version="[^"]*"/version="@@RELEASE@@"/g' setup.py

--- a/src/aws_cloudwatch_log_minder/delete_empty_log_streams.py
+++ b/src/aws_cloudwatch_log_minder/delete_empty_log_streams.py
@@ -76,7 +76,7 @@ def _delete_empty_log_streams(
                         log_stream_name,
                         last_event,
                     )
-                continue
+                    continue
 
             log.info(
                 "deleting from group %s, log stream %s, with %s bytes last event stored on %s",


### PR DESCRIPTION
When `purge_non_empty` is False, the default, empty log streams are not deleted. This appears to be the result of a typo - the continue statement is misaligned causing the block to exit before the log stream is actually deleted.