### PR TITLE
Feature: Delete log groups and other improvements

### DIFF
--- a/src/aws_cloudwatch_log_minder/__main__.py
+++ b/src/aws_cloudwatch_log_minder/__main__.py
@@ -24,8 +24,14 @@ def main(ctx, dry_run, region, profile):
 @click.pass_context
 @click.option("--days", type=int, required=False, default=30, help="retention period")
 @click.option("--overwrite", is_flag=True, default=False, help="existing retention periods")
-def set_log_retention_command(ctx, days, overwrite):
-    set_log_retention(days, overwrite, ctx.obj["dry_run"], ctx.obj["region"], ctx.obj["profile"])
+@click.option(
+    "--log-group-name-prefix",
+    type=str,
+    required=False,
+    help="of selected log group only",
+)
+def set_log_retention_command(ctx, log_group_name_prefix, days, overwrite):
+    set_log_retention(log_group_name_prefix, days, overwrite, ctx.obj["dry_run"], ctx.obj["region"], ctx.obj["profile"])
 
 
 @main.command(name="delete-empty-log-streams")

--- a/src/aws_cloudwatch_log_minder/__main__.py
+++ b/src/aws_cloudwatch_log_minder/__main__.py
@@ -2,6 +2,7 @@ import os
 import logging
 import click
 from .delete_empty_log_streams import delete_empty_log_streams
+from .delete_empty_log_groups import delete_empty_log_groups
 from .set_log_retention import set_log_retention
 
 
@@ -50,6 +51,29 @@ def set_log_retention_command(ctx, log_group_name_prefix, days, overwrite):
 )
 def delete_empty_log_streams_command(ctx, log_group_name_prefix, purge_non_empty):
     delete_empty_log_streams(
+        log_group_name_prefix,
+        purge_non_empty,
+        ctx.obj["dry_run"],
+        ctx.obj["region"],
+        ctx.obj["profile"],
+    )
+
+@main.command(name="delete-empty-log-groups")
+@click.pass_context
+@click.option(
+    "--log-group-name-prefix",
+    type=str,
+    required=False,
+    help="of selected log group only",
+)
+@click.option(
+    "--purge-non-empty",
+    is_flag=True,
+    default=False,
+    help="purge non empty streams older than retention period too",
+)
+def delete_empty_log_groups_command(ctx, log_group_name_prefix, purge_non_empty):
+    delete_empty_log_groups(
         log_group_name_prefix,
         purge_non_empty,
         ctx.obj["dry_run"],

--- a/src/aws_cloudwatch_log_minder/delete_empty_log_groups.py
+++ b/src/aws_cloudwatch_log_minder/delete_empty_log_groups.py
@@ -1,0 +1,126 @@
+import json
+from datetime import datetime, timedelta
+from typing import List
+
+import boto3
+from botocore.config import Config
+from botocore.exceptions import ClientError
+
+from .logger import log
+
+cw_logs = None
+
+
+def ms_to_datetime(ms: int) -> datetime:
+    return datetime(1970, 1, 1) + timedelta(milliseconds=ms)
+
+
+def delete_empty_log_groups(
+    log_group_name_prefix: str = None,
+    purge_non_empty: bool = False,
+    dry_run: bool = False,
+    region: str = None,
+    profile: str = None,
+):
+    global cw_logs
+
+    boto_session = boto3.Session(region_name=region, profile_name=profile)
+    cw_logs = boto_session.client("logs", config=Config(retries=dict(max_attempts=10)))
+
+    kwargs = {"PaginationConfig": {"PageSize": 50}}
+    if log_group_name_prefix:
+        kwargs["logGroupNamePrefix"] = log_group_name_prefix
+
+    log.info("finding log groups with prefix %r", log_group_name_prefix)
+    for response in cw_logs.get_paginator("describe_log_groups").paginate(**kwargs):
+        for group in response["logGroups"]:
+            _delete_empty_log_groups(group, purge_non_empty, dry_run)
+
+def _delete_empty_log_groups(
+    group: dict, purge_non_empty: bool = False, dry_run: bool = False
+):
+    now = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+    log_group_name = group["logGroupName"]
+    retention_in_days = group.get("retentionInDays", 0)
+    if not retention_in_days:
+        log.info(
+            "skipping log group %s as it has no retention period set",
+            log_group_name,
+        )
+        return
+
+    kwargs = {
+        "logGroupName": log_group_name,
+        "orderBy": "LastEventTime",
+        "descending": False,
+        "PaginationConfig": {"PageSize": 50},
+    }
+
+    for response in cw_logs.get_paginator("describe_log_streams").paginate(
+        **kwargs
+    ):
+        if len(response["logStreams"]) == 0:
+            log.info(
+                "%s deleting group %s", ("dry run" if dry_run else ""), log_group_name,
+            )
+            if dry_run:
+                continue
+
+            cw_logs.delete_log_group(logGroupName=log_group_name)
+
+
+
+def get_all_log_group_names() -> List[str]:
+    result: List[str] = []
+    for response in cw_logs.get_paginator("describe_log_groups").paginate(
+        PaginationConfig={"PageSize": 50}
+    ):
+        result.extend(list(map(lambda g: g["logGroupName"], response["logGroups"])))
+    return result
+
+
+def fan_out(
+    function_arn: str, log_group_names: List[str], purge_non_empty: bool, dry_run: bool
+):
+    awslambda = boto3.client("lambda")
+    log.info(
+        "recursively invoking %s to delete empty log streams from %d log groups",
+        function_arn,
+        len(log_group_names),
+    )
+    for log_group_name in log_group_names:
+        payload = json.dumps(
+            {
+                "log_group_name_prefix": log_group_name,
+                "purge_non_empty": purge_non_empty,
+                "dry_run": dry_run,
+            }
+        )
+        awslambda.invoke(
+            FunctionName=function_arn, InvocationType="Event", Payload=payload
+        )
+
+
+def handle(request, context):
+    global cw_logs
+
+    cw_logs = boto3.client("logs", config=Config(retries=dict(max_attempts=10)))
+
+    dry_run = request.get("dry_run", False)
+    if "dry_run" in request and not isinstance(dry_run, bool):
+        raise ValueError(f"'dry_run' is not a boolean value, {request}")
+
+    purge_non_empty = request.get("purge_non_empty", False)
+    if "purge_non_empty" in request and not isinstance(dry_run, bool):
+        raise ValueError(f"'purge_non_empty' is not a boolean value, {request}")
+
+    log_group_name_prefix = request.get("log_group_name_prefix")
+    if log_group_name_prefix:
+        delete_empty_log_groups(log_group_name_prefix, purge_non_empty, dry_run)
+    else:
+        fan_out(
+            context.invoked_function_arn,
+            get_all_log_group_names(),
+            purge_non_empty,
+            dry_run,
+        )

--- a/src/aws_cloudwatch_log_minder/delete_empty_log_streams.py
+++ b/src/aws_cloudwatch_log_minder/delete_empty_log_streams.py
@@ -28,7 +28,8 @@ def _delete_empty_log_streams(
         return
 
     log.info(
-        "deleting streams from log group %s older than the retention period of %s days",
+        "%s deleting streams from log group %s older than the retention period of %s days",
+        ("dry run" if dry_run else ""),
         log_group_name,
         retention_in_days,
     )
@@ -90,7 +91,8 @@ def _delete_empty_log_streams(
                         )
 
             log.info(
-                "deleting from group %s, log stream %s, with %s bytes last event stored on %s",
+                "%s deleting from group %s, log stream %s, with %s bytes last event stored on %s",
+                ("dry run" if dry_run else ""),
                 log_group_name,
                 log_stream_name,
                 stream["storedBytes"],


### PR DESCRIPTION
Thanks to @vjsingh who posted the code to delete empty log groups which can be found here: https://github.com/binxio/aws-cloudwatch-log-minder/issues/22

This inspired me to add it in and a few other features

- Option to delete empty log groups with dry-run 
- Add log group prefix to set log retention
- Add dry run status to logger output when enabled

This has been working great to clean up messes in cloudwatch. 