### PR TITLE
Actually delete log-groups

### DIFF
--- a/src/aws_cloudwatch_log_minder/delete_empty_log_groups.py
+++ b/src/aws_cloudwatch_log_minder/delete_empty_log_groups.py
@@ -38,8 +38,7 @@ def delete_empty_log_groups(
                 )
                 if dry_run:
                     continue
-                else:
-                    cw_logs.delete_log_group(logGroupName=log_group_name)
+                cw_logs.delete_log_group(logGroupName=log_group_name)
             else:
                 log.info(
                     "%s keeping log group %s as it is not empty",

--- a/src/aws_cloudwatch_log_minder/delete_empty_log_groups.py
+++ b/src/aws_cloudwatch_log_minder/delete_empty_log_groups.py
@@ -38,6 +38,8 @@ def delete_empty_log_groups(
                 )
                 if dry_run:
                     continue
+                else:
+                    cw_logs.delete_log_group(logGroupName=log_group_name)
             else:
                 log.info(
                     "%s keeping log group %s as it is not empty",


### PR DESCRIPTION
This PR implements the missing call to `delete_log_group` so that log groups are actually deleted. Fixes #32