### PR TITLE
Change log level for spammy messages to prevent logging heaping up

### DIFF
--- a/src/aws_cloudwatch_log_minder/delete_empty_log_groups.py
+++ b/src/aws_cloudwatch_log_minder/delete_empty_log_groups.py
@@ -31,7 +31,7 @@ def delete_empty_log_groups(
             log_group_name = group["logGroupName"]
             response = cw_logs.describe_log_streams(logGroupName=log_group_name)
             if len(response["logStreams"]) == 0:
-                log.info(
+                log.debug(
                     "%s deleting empty log group %s",
                     ("dry run" if dry_run else ""),
                     log_group_name,
@@ -40,7 +40,7 @@ def delete_empty_log_groups(
                     continue
                 cw_logs.delete_log_group(logGroupName=log_group_name)
             else:
-                log.info(
+                log.warn(
                     "%s keeping log group %s as it is not empty",
                     ("dry run" if dry_run else ""),
                     log_group_name,

--- a/src/aws_cloudwatch_log_minder/delete_empty_log_streams.py
+++ b/src/aws_cloudwatch_log_minder/delete_empty_log_streams.py
@@ -27,7 +27,7 @@ def _delete_empty_log_streams(
         )
         return
 
-    log.info(
+    log.debug(
         "%s deleting streams from log group %s older than the retention period of %s days",
         ("dry run" if dry_run else ""),
         log_group_name,
@@ -51,7 +51,7 @@ def _delete_empty_log_streams(
                 last_event > (now - timedelta(days=retention_in_days))
                 and "lastEventTimestamp" not in stream
             ):
-                log.info(
+                log.debug(
                     "keeping group %s, empty log stream %s, created on %s",
                     log_group_name,
                     log_stream_name,
@@ -84,13 +84,13 @@ def _delete_empty_log_streams(
                         continue
                 except ClientError as e:
                     if e.response["Error"]["Code"] == "ResourceNotFoundException":
-                        log.info(
+                        log.warn(
                             "log stream %s from group %s no longer present in cloudwatch",
                             log_stream_name,
                             log_group_name,
                         )
 
-            log.info(
+            log.debug(
                 "%s deleting from group %s, log stream %s, with %s bytes last event stored on %s",
                 ("dry run" if dry_run else ""),
                 log_group_name,
@@ -107,7 +107,7 @@ def _delete_empty_log_streams(
                 )
             except ClientError as e:
                 if e.response["Error"]["Code"] == "ResourceNotFoundException":
-                    log.info(
+                    log.warn(
                         "log stream %s from group %s already deleted",
                         log_stream_name,
                         log_group_name,


### PR DESCRIPTION
We noticed that the default settings for logging just log all the things, and since we use this functionality as a lambda we saw a massive amount of logging for the lambda in cloudwatch. To prevent spammy messages I changed the loglevel for several of the spammy messages to debug and some errors to warning. 